### PR TITLE
Fixed a bug in the methods to delete name, given name and last name of instances of the ResponsibleAgent class.

### DIFF
--- a/oc_ocdm/graph/entities/bibliographic/responsible_agent.py
+++ b/oc_ocdm/graph/entities/bibliographic/responsible_agent.py
@@ -64,7 +64,7 @@ class ResponsibleAgent(BibliographicEntity):
         self._create_literal(GraphEntity.iri_name, string)
 
     def remove_name(self) -> None:
-        self.g.remove((self.g, GraphEntity.iri_name, None))
+        self.g.remove((self.res, GraphEntity.iri_name, None))
 
     # HAS GIVEN NAME
     def get_given_name(self) -> Optional[str]:
@@ -78,7 +78,7 @@ class ResponsibleAgent(BibliographicEntity):
         self._create_literal(GraphEntity.iri_given_name, string)
 
     def remove_given_name(self) -> None:
-        self.g.remove((self.g, GraphEntity.iri_given_name, None))
+        self.g.remove((self.res, GraphEntity.iri_given_name, None))
 
     # HAS FAMILY NAME
     def get_family_name(self) -> Optional[str]:
@@ -92,7 +92,7 @@ class ResponsibleAgent(BibliographicEntity):
         self._create_literal(GraphEntity.iri_family_name, string)
 
     def remove_family_name(self) -> None:
-        self.g.remove((self.g, GraphEntity.iri_family_name, None))
+        self.g.remove((self.res, GraphEntity.iri_family_name, None))
 
     # HAS RELATED AGENT
     def get_related_agents(self) -> List[URIRef]:


### PR DESCRIPTION
I found and fixed a small bug in the _remove_name_, _remove_given_name_ and _remove_family_name_ methods of the ResponsibleAgent class. I'll report the code with and without the bug regarding _remove_family_name_, but the same goes for the other two functions:

```python
# Code with the bug: self.g is not a subject
def remove_family_name(self) -> None:
    self.g.remove((self.g, GraphEntity.iri_family_name, None))

# Code without the bug: self.g -> self.res
def remove_family_name(self) -> None:
    self.g.remove((self.res, GraphEntity.iri_family_name, None))
```