### PR TITLE
The peer review, web content and proceedings series were added to the bibliographic resources' types

### DIFF
--- a/oc_ocdm/graph/entities/bibliographic/bibliographic_resource.py
+++ b/oc_ocdm/graph/entities/bibliographic/bibliographic_resource.py
@@ -852,6 +852,21 @@ class BibliographicResource(BibliographicEntity):
         """
         self._create_type(GraphEntity.iri_book)
 
+    def create_peer_review(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``fr:ReviewVersion``.
+
+        **WARNING: the OCDM specification admits at most two types for an entity.
+        The main type cannot be edited or removed. Any existing secondary type
+        will be overwritten!**
+
+        `The type of the bibliographic resource`
+
+        :return: None
+        """
+        self._create_type(GraphEntity.iri_peer_review)
+
     def create_proceedings_article(self) -> None:
         """
         Setter method corresponding to the ``rdf:type`` RDF predicate.
@@ -881,6 +896,21 @@ class BibliographicResource(BibliographicEntity):
         :return: None
         """
         self._create_type(GraphEntity.iri_academic_proceedings)
+
+    def create_proceedings_series(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``fabio:Series``.
+
+        **WARNING: the OCDM specification admits at most two types for an entity.
+        The main type cannot be edited or removed. Any existing secondary type
+        will be overwritten!**
+
+        `The type of the bibliographic resource`
+
+        :return: None
+        """
+        self._create_type(GraphEntity.iri_proceedings_series)
 
     def create_reference_book(self) -> None:
         """
@@ -1001,6 +1031,21 @@ class BibliographicResource(BibliographicEntity):
         :return: None
         """
         self._create_type(GraphEntity.iri_expression_collection)
+
+    def create_web_content(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``fabio:WebContent``.
+
+        **WARNING: the OCDM specification admits at most two types for an entity.
+        The main type cannot be edited or removed. Any existing secondary type
+        will be overwritten!**
+
+        `The type of the bibliographic resource`
+
+        :return: None
+        """
+        self._create_type(GraphEntity.iri_web_content)
 
     def create_other(self) -> None:
         """

--- a/oc_ocdm/graph/graph_entity.py
+++ b/oc_ocdm/graph/graph_entity.py
@@ -36,6 +36,7 @@ class GraphEntity(AbstractEntity):
     DOCO: ClassVar[Namespace] = Namespace("http://purl.org/spar/doco/")
     FABIO: ClassVar[Namespace] = Namespace("http://purl.org/spar/fabio/")
     FOAF: ClassVar[Namespace] = Namespace("http://xmlns.com/foaf/0.1/")
+    FR: ClassVar[Namespace] = Namespace("http://purl.org/spar/fr/")
     FRBR: ClassVar[Namespace] = Namespace("http://purl.org/vocab/frbr/core#")
     LITERAL: ClassVar[Namespace] = Namespace("http://www.essepuntato.it/2010/06/literalreification/")
     OA: ClassVar[Namespace] = Namespace("http://www.w3.org/ns/oa#")
@@ -97,13 +98,16 @@ class GraphEntity(AbstractEntity):
     iri_journal_issue: ClassVar[URIRef] = FABIO.JournalIssue
     iri_journal_volume: ClassVar[URIRef] = FABIO.JournalVolume
     iri_manifestation: ClassVar[URIRef] = FABIO.Manifestation
+    iri_peer_review: ClassVar[URIRef] = FR.ReviewVersion
     iri_proceedings_paper: ClassVar[URIRef] = FABIO.ProceedingsPaper
+    iri_proceedings_series: ClassVar[URIRef] = FABIO.Series
     iri_reference_book: ClassVar[URIRef] = FABIO.ReferenceBook
     iri_reference_entry: ClassVar[URIRef] = FABIO.ReferenceEntry
     iri_report_document: ClassVar[URIRef] = FABIO.ReportDocument
     iri_series: ClassVar[URIRef] = FABIO.Series
     iri_specification_document: ClassVar[URIRef] = FABIO.SpecificationDocument
     iri_thesis: ClassVar[URIRef] = FABIO.Thesis
+    iri_web_content: ClassVar[URIRef] = FABIO.WebContent
     iri_agent: ClassVar[URIRef] = FOAF.Agent
     iri_family_name: ClassVar[URIRef] = FOAF.familyName
     iri_given_name: ClassVar[URIRef] = FOAF.givenName


### PR DESCRIPTION
I added three new types of bibliographic resource:

Peer review -> [fr:ReviewVersion](http://purl.org/spar/fr/ReviewVersion)
Proceedings series -> [fabio:Series](http://purl.org/spar/fabio/Series)
Web content -> [fabio:WebContent](http://purl.org/spar/fabio/WebContent)

The OCDM has already been updated accordingly (https://github.com/opencitations/metadata/pull/11).