### PR TITLE
Bugfix: missing encoding in reader._load_graph

### DIFF
--- a/oc_ocdm/reader.py
+++ b/oc_ocdm/reader.py
@@ -88,7 +88,7 @@ class Reader(object):
         for cur_format in formats:
             try:
                 if cur_format == "json-ld":
-                    with open(file_path, "rt") as f:
+                    with open(file_path, "rt", encoding="utf-8") as f:
                         json_ld_file: Any = json.load(f)
                         if isinstance(json_ld_file, dict):
                             json_ld_file: List[Any] = [json_ld_file]


### PR DESCRIPTION
The missing encoding in reader._load_graph raised an IOError exception when trying to read a json-ld file. I solved the problem by adding encoding.