### PR TITLE
filelock added in reader and storer

### DIFF
--- a/oc_ocdm/storer.py
+++ b/oc_ocdm/storer.py
@@ -14,6 +14,7 @@
 # ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
 from __future__ import annotations
+from filelock import FileLock
 
 import os
 import json
@@ -118,9 +119,10 @@ class Storer(object):
                         item["@context"] = context_path
             else:
                 cur_json_ld: Any = json.loads(new_g.serialize(format="json-ld"))
-
-            with open(cur_file_path, 'wt', encoding='utf-8') as f:
-                json.dump(cur_json_ld, f, indent=4, ensure_ascii=False)
+            lock = FileLock(f"{cur_file_path}.lock")
+            with lock:
+                with open(cur_file_path, 'wt', encoding='utf-8') as f:
+                    json.dump(cur_json_ld, f, indent=4, ensure_ascii=False)
         else:
             new_g.serialize(cur_file_path, format=self.output_format, encoding="utf-8")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,6 +80,18 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "filelock"
+version = "3.6.0"
+description = "A platform independent file lock."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
 name = "hbreader"
 version = "0.9.1"
 description = "Honey Badger reader - a generic file/url/string open and read tool"
@@ -518,7 +530,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.4"
-content-hash = "95bdfcf45d232dfb02f61de2f8884aaf62e286dcdb96e418c4e25e46dbce93c5"
+content-hash = "99a4dbca9f14f53f635797c193640b1779cd94698a12ce06eaaf35638776fb4a"
 
 [metadata.files]
 alabaster = [
@@ -554,6 +566,10 @@ colorama = [
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+]
+filelock = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
 hbreader = [
     {file = "hbreader-0.9.1-py3-none-any.whl", hash = "sha256:9a6e76c9d1afc1b977374a5dc430a1ebb0ea0488205546d4678d6e31cc5f6801"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ python = "^3.7.4"
 rdflib = "^6.0.0"
 PyShEx = "^0.8.0"
 SPARQLWrapper = "^1.8.5"
+filelock = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 Sphinx = "^4.4.0"


### PR DESCRIPTION
I added filelocks to the `Reader` and `Storer` objects using your recommended [py-filelock](https://py-filelock.readthedocs.io/en/latest/) library. 
This change was crucial for opencitations/meta to operate quickly in multiprocess. 

It works like a charm, but there is a problem: .lock files are not automatically deleted on UNIX, only on Windows. The reason is extensively discussed in [this post](https:///stackoverflow.com/questions/58098634/why-python-filelock-library-delete-lockfiles-on-windows-but-notunix).

I tried using `multiprocessing.Lock()` on `Storer.store_all` inside Meta to avoid modifying oc_ocdm, but in this way, I put a lock on the reading and writing operations of every single process and not on the single file, creating a severe bottleneck.

Temporarily, I’m deleting the .lock files at the end of the Meta process so that at least Meta is usable, but I understand that it is not an optimal solution. What do you think? Do you know how to delete .lock files on UNIX without creating race conditions?