### PR TITLE
oc_ocdm extension: Discourse Element entities admit more rhetorical types

### DIFF
--- a/oc_ocdm/graph/entities/bibliographic/discourse_element.py
+++ b/oc_ocdm/graph/entities/bibliographic/discourse_element.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from oc_ocdm.graph.entities.bibliographic.pointer_list import PointerList
 from oc_ocdm.graph.graph_entity import GraphEntity
 from oc_ocdm.graph.entities.bibliographic_entity import BibliographicEntity
+from oc_ocdm.support.support import create_type
 
 
 class DiscourseElement(BibliographicEntity):
@@ -512,3 +513,68 @@ class DiscourseElement(BibliographicEntity):
         :return: None
         """
         self._create_type(GraphEntity.iri_caption)
+
+
+    def create_introduction(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Introduction``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+
+        create_type(self.g, self.res, GraphEntity.iri_introduction)
+
+    def create_methods(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Methods``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_methods)
+
+    def create_materials(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Materials``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_materials)
+
+    def create_related_work(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:RelatedWork``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_related_work)
+
+    def create_results(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Results``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_results)
+
+    def create_discussion(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Discussion``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_discussion)
+
+    def create_conclusion(self) -> None:
+        """
+        Setter method corresponding to the ``rdf:type`` RDF predicate.
+        It implicitly sets the object value ``deo:Conclusion``.
+
+        **WARNING: any existing rhetorical type WILL NOT be overwritten.**
+        """
+        create_type(self.g, self.res, GraphEntity.iri_conclusion)

--- a/oc_ocdm/graph/graph_entity.py
+++ b/oc_ocdm/graph/graph_entity.py
@@ -84,6 +84,13 @@ class GraphEntity(AbstractEntity):
     iri_paragraph: ClassVar[URIRef] = DOCO.Paragraph
     iri_part: ClassVar[URIRef] = DOCO.Part
     iri_section: ClassVar[URIRef] = DOCO.Section
+    iri_introduction: ClassVar[URIRef] = DEO.Introduction
+    iri_methods: ClassVar[URIRef] = DEO.Methods
+    iri_materials: ClassVar[URIRef] = DEO.Materials
+    iri_related_work: ClassVar[URIRef] = DEO.RelatedWork
+    iri_results: ClassVar[URIRef] = DEO.Results
+    iri_discussion: ClassVar[URIRef] = DEO.Discussion
+    iri_conclusion: ClassVar[URIRef] = DEO.Conclusion
     iri_section_title: ClassVar[URIRef] = DOCO.SectionTitle
     iri_sentence: ClassVar[URIRef] = DOCO.Sentence
     iri_table: ClassVar[URIRef] = DOCO.Table

--- a/oc_ocdm/test/graph/entities/bibliographic/test_bibliographic_resource.py
+++ b/oc_ocdm/test/graph/entities/bibliographic/test_bibliographic_resource.py
@@ -343,6 +343,16 @@ class TestBibliographicResource(unittest.TestCase):
         triple = self.br1.res, RDF.type, GraphEntity.iri_expression
         self.assertIn(triple, self.br1.g)
 
+    def test_assign_more_types_br(self):
+        result1 = self.br1.create_series()
+        self.assertIsNone(result1)
+        result2 = self.br1.create_preprint()
+        self.assertIsNone(result2)
+
+        triple1 = self.br1.res, RDF.type, GraphEntity.iri_series
+        triple2 = self.br1.res, RDF.type, GraphEntity.iri_preprint
+        self.assertIn(triple2, self.br1.g) and not self.assertIn(triple1, self.br1.g)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/oc_ocdm/test/graph/entities/bibliographic/test_discourse_element.py
+++ b/oc_ocdm/test/graph/entities/bibliographic/test_discourse_element.py
@@ -134,6 +134,26 @@ class TestDiscourseElement(unittest.TestCase):
         triple = self.de1.res, RDF.type, GraphEntity.iri_caption
         self.assertIn(triple, self.de1.g)
 
+    def test_assign_more_structural_types_de(self):
+        result1 = self.de1.create_table()
+        self.assertIsNone(result1)
+        result2 = self.de1.create_footnote()
+        self.assertIsNone(result2)
+
+        triple1 = self.de1.res, RDF.type, GraphEntity.iri_table
+        triple2 = self.de1.res, RDF.type, GraphEntity.iri_footnote
+        self.assertIn(triple2, self.de1.g) and not self.assertIn(triple1, self.de1.g)
+
+    def test_assign_more_rhetorical_types_de(self):
+        result1 = self.de1.create_materials()
+        self.assertIsNone(result1)
+        result2 = self.de1.create_methods()
+        self.assertIsNone(result2)
+
+        triple1 = self.de1.res, RDF.type, GraphEntity.iri_materials
+        triple2 = self.de1.res, RDF.type, GraphEntity.iri_methods
+        self.assertIn(triple2, self.de1.g) and self.assertIn(triple1, self.de1.g)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The class Discourse Element has been enriched with different methods to attribute rhetorical types according to the DEO ontology (Introduction, Materials, Methods, Related Work, Results, Discussion, Conclusion). As a general rule, the OCDM specification admits at most two types for an entity, but different rhetorical types can be attributed to the same discourse element. 